### PR TITLE
Increase YNAB max lengths to follow API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## (unreleased)
 
+- Increase memo and payee max lengths, following changes in YNAB's API
+  ([243b60b](243b60b90efe2e70e50156d1a9cc4330f81cb563))
+
 ## 0.1.4 (2024-08-25)
 
-- Fix `months_to_sync` configuration key not being unsed
+- Fix `months_to_sync` configuration key not being used
   ([889d241](889d241ce5a56672e2fd9dac639fc29b78aea168))
 - Log how many transactions were actually imported vs duplicates
   ([a7d21de](a7d21de7b26319c362d3dda0119de3167042cc9b))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    ynab (3.4.0)
+    ynab (3.6.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
 PLATFORMS


### PR DESCRIPTION
# What?

Increase YNAB memo and payee name limits to 500 and 200 characters respectively.

# Why?

The API will be updated soon to allow for longer memo and payee names.
See https://github.com/ynab/ynab-sdk-ruby/issues/77 for more details.

# How?

Extract "magic numbers" to constants, then update their values.

# What else?

This can't be merged until the changes have been made to YNAB's API (server _and_ client?).
This PR may come with a gem update too.
