### PR TITLE
Refresh accounts on Money Forward before downloading CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## (unreleased)
 
+- Refresh accounts on Money Forward before syncing transactions to YNAB.
+  ([TBD]())
 - (Fix) Handle scenario where multiple YNAB accounts may match the partial string passed in the config file.
   ([TBD]())
 - Increase memo and payee max lengths, following changes in YNAB's API

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     mfynab (0.1.4)
       csv
       ferrum (~> 0.15)
+      nokogiri (~> 1.18)
       psych
       ynab (~> 3.6)
 
@@ -47,6 +48,8 @@ GEM
     minitest (5.25.4)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
+    nokogiri (1.18.3-arm64-darwin)
+      racc (~> 1.4)
     parallel (1.26.3)
     parser (3.3.7.1)
       ast (~> 2.4.1)

--- a/README.md
+++ b/README.md
@@ -73,13 +73,10 @@ Then, run `bin/rake test` to run the tests.
 
 ## Roadmap
 
-### Refresh bank accounts in Money Forward
+### Deploy/Automate
 
-Using the browser, log in, then press the 更新 button for each account declared in the config file.
-
-Tricky parts:
-- Refreshing can take some time, so we should also implement a way to check progess. (Does it show 更新中 and a loading spinner for that account?)
-- Sometimes, Money Forward needs to fill a captcha or one-time password. How can I pass that to mfynab and have it fill it?
+I'd like to be able to deploy something to a server, that would run the sync on a schedule (eg. every hour or day).
+I could for example use Kamal to produce a Docker image that includes all needed secrets and will run a script on a schedule.
 
 ### Better session management
 
@@ -91,11 +88,6 @@ Previous notes:
   - Or prompt user from credentials in terminal and fill in form in headless browser
   - Need to handle case when cookie has expired:
     > セキュリティ設定	最終利用時間から[30日]後に自動ログアウト
-
-### Deploy/Automate
-
-I'd like to be able to deploy something to a server, that would run the sync on a schedule (eg. every hour or day).
-I could for example use Kamal to produce a Docker image that includes all needed secrets and will run a script on a schedule.
 
 ### Later
 
@@ -122,3 +114,4 @@ I could for example use Kamal to produce a Docker image that includes all needed
   Imported 24 transactions for DDD (0 duplicates)
   ```
 - Passing logger everywhere feels weird.
+- Prompt user for captcha and other account extra authentication required by Money Forward?

--- a/lib/mfynab/cli.rb
+++ b/lib/mfynab/cli.rb
@@ -19,6 +19,8 @@ module MFYNAB
     def start
       logger.info("Running...")
 
+      money_forward.update_accounts(money_forward_account_names)
+
       Dir.mktmpdir("mfynab") do |save_path|
         money_forward.download_csv(
           path: save_path,
@@ -36,6 +38,10 @@ module MFYNAB
     private
 
       attr_reader :argv
+
+      def money_forward_account_names
+        @_money_forward_account_names = config["accounts"].map { _1["money_forward_name"] }
+      end
 
       def ynab_transaction_importer
         @_ynab_transaction_importer ||= YnabTransactionImporter.new(

--- a/lib/mfynab/money_forward.rb
+++ b/lib/mfynab/money_forward.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "nokogiri"
+require "mfynab/money_forward/account_status"
+
 module MFYNAB
   class MoneyForward
     CSV_PATH = "/cf/csv"
@@ -7,6 +10,26 @@ module MFYNAB
     def initialize(session, logger:)
       @session = session
       @logger = logger
+    end
+
+    def update_accounts(account_names)
+      account_statuses = AccountStatus::Fetcher.new(session, logger: logger).fetch(account_names: account_names)
+
+      finished = account_statuses.map do |account_status|
+        ensure_account_updated(account_status)
+      end.all?
+
+      return if finished
+
+      logger.info("Waiting for a while before checking status again...")
+      # FIXME: I'm never comfortable with using sleep().
+      # Do I want to implement a solution based on callbacks?
+      # For example, the script could say:
+      # > Accounts are out of date.
+      # > I triggered the updates, and will call myself again in X seconds/minutes.
+      # > When the accounts are updated, I'll proceed to the next step.
+      sleep(5)
+      update_accounts(account_names)
     end
 
     def download_csv(path:, months:)
@@ -27,6 +50,7 @@ module MFYNAB
       end
     end
 
+    # FIXME: make private or inline
     def download_csv_string(date:)
       # FIXME: handle errors/edge cases
       session
@@ -38,5 +62,40 @@ module MFYNAB
     private
 
       attr_reader :session, :logger
+
+      def ensure_account_updated(account_status)
+        updated = false
+
+        status_log = "#{account_status.name}:\t#{account_status.key}"
+        case account_status.key
+        when :success
+          status_log << " (#{account_status.updated_at})"
+          if account_status.outdated?
+            status_log << " - Will update"
+            account_status.trigger_update(session)
+          else
+            updated = true
+          end
+        when :processing
+          status_log << " - Updating"
+        else
+          # FIXME: I think I need to try and update accounts with weird state at least once,
+          # to confirm whether it's resolved.
+          status_log << " - Ignoring"
+          # FIXME: we can probably handle :additional_request and/or :login right here in the script,
+          # when we find the time.
+          # FIXME: sometimes, nothing can be done about the status, for example, I can currently see モバイルSUICA
+          # show an `errors` status with this message:
+          # ただいま大変混み合っております。今しばらくお待ちいただきますようお願いいたします。 失敗日時：02/22 14:03
+          # In other words: "please wait". Maybe improve messaging?
+          updated = true # There's nothing to wait on here.
+          logger.warn(account_status.invalid_state_warning)
+        end
+
+        # FIXME: I'll probably want to refresh the display instead of relogging everything every 5 seconds.
+        logger.info(status_log)
+
+        updated
+      end
   end
 end

--- a/lib/mfynab/money_forward/account_status.rb
+++ b/lib/mfynab/money_forward/account_status.rb
@@ -95,6 +95,15 @@ module MFYNAB
         updated_at < Time.now - FRESHNESS_LIMIT
       end
 
+      def should_update?(update_invalid:)
+        (key == :success && outdated?) ||
+          (update_invalid && failed_state?)
+      end
+
+      def failed_state?
+        !%i[success processing].include?(key)
+      end
+
       def trigger_update(session)
         session.http_post(
           "/faggregation_queue2/#{id_hash}",

--- a/lib/mfynab/money_forward/account_status.rb
+++ b/lib/mfynab/money_forward/account_status.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "ferrum"
+require "net/http"
+require "nokogiri"
+require "uri"
+
+module MFYNAB
+  class MoneyForward
+    class AccountStatus
+      class Fetcher
+        def initialize(session, logger:)
+          @logger = logger
+          @session = session
+        end
+
+        def fetch(account_names:)
+          logger.info("Checking Money Forward accounts status")
+          html = session.http_get("/accounts")
+          table_rows_selector = "section.accounts section.common-account-table-container > table > tr[id]"
+          Nokogiri::HTML(html).css(table_rows_selector).filter_map do |node|
+            account = parse_html_table_row(node)
+            next unless account_names.include?(account.name)
+
+            status_data = determine_status_data(account)
+            account.assign_status_data(**status_data)
+
+            account
+          end
+        end
+
+        private
+
+          attr_reader :session, :logger
+
+          def determine_status_data(account)
+            case account.raw_status
+            when "正常" then { key: :success }
+            when "更新中" then { key: :processing }
+            else
+              body = session.http_get("/accounts/polling/#{account.id_hash}")
+              # JSON format:
+              #  - loading: boolean
+              #  - message: Japanese text
+              #  - status: success, processing, additional_request, errors, important_announcement,
+              #            invalid_password, login, suspended
+              # FIXME: make more robust
+              queried_status = JSON.parse(body)
+              {
+                key: queried_status["status"].to_sym,
+                message: queried_status["message"],
+              }
+            end
+          end
+
+          def parse_html_table_row(node)
+            AccountStatus.new(
+              id_hash: node[:id],
+              name: node.xpath("td").first.text.lines[1].strip,
+              raw_status: node.css("td.account-status>span:not([id*='hidden'])").text.strip,
+              # FIXME: can this be a little more robust?
+              #  - this should not depend on the timezone the server is running in
+              #  - this should explicitly fail if parsing is not possible
+              #  - what if it's January 1st and last update was last year?
+              updated_at: Time.parse(node.css("td.created").text[/(?<=\().*?(?=\))/]),
+            )
+          end
+      end
+
+      FRESHNESS_LIMIT = 24 * 60 * 60 # 1 day
+
+      attr_reader :id_hash, :name, :raw_status, :updated_at, :key, :message
+
+      def initialize(id_hash:, name:, raw_status:, updated_at:)
+        @id_hash = id_hash
+        @name = name
+        @raw_status = raw_status
+        @updated_at = updated_at
+      end
+
+      def assign_status_data(key:, message: nil)
+        @key = key
+        @message = message
+      end
+
+      def invalid_state_warning
+        warning = "The Money Forward account named #{name} is in an invalid state: #{key}"
+        warning << " (#{message})" if message
+        warning << ". Please handle the issue manually to resume syncing."
+      end
+
+      def outdated?
+        # Require accounts to have been updated in the last day
+        # FIXME: make configurable?
+        updated_at < Time.now - FRESHNESS_LIMIT
+      end
+
+      def trigger_update(session)
+        session.http_post(
+          "/faggregation_queue2/#{id_hash}",
+          URI.encode_www_form(commit: "更新"),
+          "X-CSRF-Token" => session.csrf_token,
+        )
+      end
+    end
+  end
+end

--- a/mfynab.gemspec
+++ b/mfynab.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "csv"
   spec.add_dependency "ferrum", "~> 0.15"
+  spec.add_dependency "nokogiri", "~> 1.18"
   spec.add_dependency "psych"
   spec.add_dependency "ynab", "~> 3.6"
 end

--- a/test/mfynab/money_forward/account_status_test.rb
+++ b/test/mfynab/money_forward/account_status_test.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "mfynab/money_forward/account_status"
+require "support/test_loggers"
+
+module MFYNAB
+  class MoneyForward
+    class AccountStatusTest < Minitest::Test
+      include TestLoggers
+
+      def test_fetch
+        # FIXME: should I use WebMock instead of relying on implementation details?
+        # This would allow me to assert that the HTTP request made is correct
+        # (e.g. the path, headers, cookie)
+        mock_session = Minitest::Mock.new
+        html = accounts_page_html(
+          [
+            {
+              id: "account-1",
+              name: "Account 1",
+              updated_at: Time.new(Time.now.year, 2, 22, 13, 57),
+              status: :updated,
+            },
+            {
+              id: "account-2",
+              name: "Account 2",
+              updated_at: Time.new(Time.now.year, 2, 22, 15, 37),
+              status: :updating,
+            },
+          ],
+        )
+        mock_session.expect(:http_get, html, ["/accounts"])
+
+        fetcher = AccountStatus::Fetcher.new(mock_session, logger: null_logger)
+        accounts = fetcher.fetch(account_names: ["Account 1", "Account 2"])
+
+        assert_equal 2, accounts.size
+        assert_equal ["Account 1", "Account 2"], accounts.map(&:name)
+        assert_equal %i[success processing], accounts.map(&:key)
+
+        expected_date = Time.new(Time.now.year, 2, 22, 13, 57)
+
+        assert_equal expected_date, accounts[0].updated_at
+      end
+
+      def test_fetch_ignores_unwanted_accounts
+        mock_session = Minitest::Mock.new
+        html = accounts_page_html(
+          [
+            {
+              id: "account-1",
+              name: "Account 1",
+              updated_at: Time.new(Time.now.year, 2, 22, 13, 57),
+              status: :updated,
+            },
+            {
+              id: "account-2",
+              name: "Account 2",
+              updated_at: Time.new(Time.now.year, 2, 22, 15, 37),
+              status: :updating,
+            },
+          ],
+        )
+        mock_session.expect(:http_get, html, ["/accounts"])
+
+        fetcher = AccountStatus::Fetcher.new(mock_session, logger: null_logger)
+        accounts = fetcher.fetch(account_names: ["Account 1"])
+
+        assert_equal 1, accounts.size
+        assert_equal "Account 1", accounts.first.name
+      end
+
+      def test_fetch_with_additional_request
+        mock_session = Minitest::Mock.new
+        html = accounts_page_html(
+          [
+            {
+              id: "account-1",
+              name: "Account 1",
+              updated_at: Time.new(Time.now.year, 2, 22, 13, 57),
+              status: :errors,
+            },
+          ],
+        )
+        json = { "loading" => false, "status" => "errors", "message" => "error message" }.to_json
+        # FIXME: should I use WebMock instead of relying on implementation details?
+
+        mock_session.expect(:http_get, html, ["/accounts"])
+        additional_query_mock = mock_session.expect(:http_get, json, ["/accounts/polling/account-1"])
+
+        fetcher = AccountStatus::Fetcher.new(mock_session, logger: null_logger)
+        accounts = fetcher.fetch(account_names: ["Account 1"])
+
+        additional_query_mock.verify
+
+        assert_equal 1, accounts.size
+        account = accounts.first
+
+        assert_equal "Account 1", account.name
+        assert_equal :errors, account.key
+        assert_equal "error message", account.message
+      end
+
+      private
+
+        def accounts_page_html(accounts)
+          html = +<<~HTML
+            <section class="accounts">
+              <section class="common-account-table-container">
+                <table>
+                  <tr>
+                    <th>金融機関</th>
+                    <th>登録日（最終取得日）</th>
+                    <th>更新状態</th>
+                  </tr>
+          HTML
+          accounts.each do |account|
+            html << <<~HTML
+              <tr id="#{account[:id]}">
+                <td class="service">
+                  #{account[:name]}
+                </td>
+                <td class="created">2023/09/20 (#{account[:updated_at].strftime('%m/%d %H:%M')})</td>
+                <td class="account-status">
+                  <span id="js-#{'hidden-' unless account[:status] == :updated}status-sentence-1-updated">正常</span>
+                  <span id="js-#{'hidden-' unless account[:status] == :updating}status-sentence-1-updating">更新中</span>
+                </td>
+              </tr>
+            HTML
+          end
+          html << <<~HTML
+                </table>
+              </section>
+            </section>
+          HTML
+        end
+    end
+  end
+end


### PR DESCRIPTION
This ensures we fetch as many transactions as we can from Money Forward
to put in YNAB.

~~This first commit is a rough (but working) implementation of the concept.~~
~~I'll start working on testing, polishing and refactoring next.~~
