### PR TITLE
Fetch credentials from config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (unreleased)
 
+- Credentials can now be stored in the config file.
+  (This change is backwards compatible.)
 - The configuration YAML file does not need a top-level key anymore.
   (This change is backwards compatible.)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## (unreleased)
 
+- The configuration YAML file does not need a top-level key anymore.
+  (This change is backwards compatible.)
+
 ## 0.2.0 (2025-03-25)
 
 - Refresh accounts on Money Forward before syncing transactions to YNAB.

--- a/README.md
+++ b/README.md
@@ -26,13 +26,32 @@ gem install mfynab
 wget https://raw.githubusercontent.com/davidstosik/moneyforward_ynab/main/config/example.yml -O mfynab-david.yml
 ```
 
-The script currently looks for credentials in environment variables:
+Credentials can be set in your config file directly:
 
-- `MONEYFORWARD_USERNAME`
-- `MONEYFORWARD_PASSWORD`
-- `YNAB_ACCESS_TOKEN`
+```yml
+credentials:
+  ynab_access_token: "plain_text_access_token"
+  moneyforward_username: "david@example.com"
+  moneyforward_password: "plain_text_password"
+```
 
-You can for example use [dotenv](https://github.com/bkeepers/dotenv)
+It is also possible to have the config fetch secrets from environment variables (this is the default in the example config file):
+
+```yml
+credentials:
+  ynab_access_token:
+    type: "env"
+    value: "YNAB_ACCESS_TOKEN"
+  moneyforward_username:
+    type: "env"
+    value: "MONEYFORWARD_USERNAME"
+  moneyforward_password:
+    type: "env"
+    value: "MONEYFORWARD_PASSWORD"
+```
+
+If using environment variables, you can for example also use
+[dotenv](https://github.com/bkeepers/dotenv)
 to store your secrets in a `.env` file:
 
 ```
@@ -41,8 +60,8 @@ MONEYFORWARD_PASSWORD=Passw0rd!
 YNAB_ACCESS_TOKEN=abunchofcharacters
 ```
 
-Alternatively, you can also use something [1Password's CLI](https://developer.1password.com/docs/cli/)
-to avoid storing clear secrets:
+Alternatively, you can also use something like [1Password's CLI](https://developer.1password.com/docs/cli/)
+to completely avoid storing clear secrets:
 
 ```
 MONEYFORWARD_USERNAME=op://Private/Moneyforward/username

--- a/config/example.yml
+++ b/config/example.yml
@@ -1,8 +1,7 @@
-David:
-  ynab_budget: "My budget"
-  months_to_sync: 3
-  accounts:
-    - money_forward_name: "楽天銀行"
-      ynab_name: "Rakuten Bank"
-    - money_forward_name: "楽天カード"
-      ynab_name: "Rakuten Card"
+ynab_budget: "My budget"
+months_to_sync: 3
+accounts:
+  - money_forward_name: "楽天銀行"
+    ynab_name: "Rakuten Bank"
+  - money_forward_name: "楽天カード"
+    ynab_name: "Rakuten Card"

--- a/config/example.yml
+++ b/config/example.yml
@@ -1,5 +1,15 @@
 ynab_budget: "My budget"
 months_to_sync: 3
+credentials:
+  ynab_access_token:
+    type: "env"
+    value: "YNAB_ACCESS_TOKEN"
+  moneyforward_username:
+    type: "env"
+    value: "MONEYFORWARD_USERNAME"
+  moneyforward_password:
+    type: "env"
+    value: "MONEYFORWARD_PASSWORD"
 accounts:
   - money_forward_name: "楽天銀行"
     ynab_name: "Rakuten Bank"

--- a/lib/mfynab/cli.rb
+++ b/lib/mfynab/cli.rb
@@ -19,20 +19,9 @@ module MFYNAB
 
     def start
       logger.info("Running...")
-
       money_forward.update_accounts(money_forward_account_names)
-
-      Dir.mktmpdir("mfynab") do |save_path|
-        money_forward.download_csv(
-          path: save_path,
-          months: config.months_to_sync,
-        )
-
-        data = MoneyForwardData.new(logger: logger)
-        data.read_all_csv(save_path)
-        ynab_transaction_importer.run(data.to_h)
-      end
-
+      data = money_forward.fetch_data(config.months_to_sync)
+      ynab_transaction_importer.run(data.to_h)
       logger.info("Done!")
     end
 

--- a/lib/mfynab/cli.rb
+++ b/lib/mfynab/cli.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "yaml"
+require "mfynab/config"
 require "mfynab/money_forward"
 require "mfynab/money_forward/session"
 require "mfynab/money_forward_data"
@@ -24,7 +25,7 @@ module MFYNAB
       Dir.mktmpdir("mfynab") do |save_path|
         money_forward.download_csv(
           path: save_path,
-          months: months_to_sync,
+          months: config.months_to_sync,
         )
 
         data = MoneyForwardData.new(logger: logger)
@@ -40,20 +41,16 @@ module MFYNAB
       attr_reader :argv
 
       def money_forward_account_names
-        @_money_forward_account_names = config["accounts"].map { _1["money_forward_name"] }
+        @_money_forward_account_names = config.accounts.map { _1["money_forward_name"] }
       end
 
       def ynab_transaction_importer
         @_ynab_transaction_importer ||= YnabTransactionImporter.new(
-          config["ynab_access_token"],
-          config["ynab_budget"],
-          config["accounts"],
+          secrets["ynab_access_token"],
+          config.ynab_budget,
+          config.accounts,
           logger: logger,
         )
-      end
-
-      def months_to_sync
-        config.fetch("months_to_sync", 3)
       end
 
       def money_forward
@@ -62,10 +59,18 @@ module MFYNAB
 
       def session
         @_session ||= MoneyForward::Session.new(
-          username: config["moneyforward_username"],
-          password: config["moneyforward_password"],
+          username: secrets["moneyforward_username"],
+          password: secrets["moneyforward_password"],
           logger: logger,
         )
+      end
+
+      def secrets
+        {
+          "ynab_access_token" => ENV.fetch("YNAB_ACCESS_TOKEN"),
+          "moneyforward_username" => ENV.fetch("MONEYFORWARD_USERNAME"),
+          "moneyforward_password" => ENV.fetch("MONEYFORWARD_PASSWORD"),
+        }
       end
 
       def config_file
@@ -75,15 +80,7 @@ module MFYNAB
       end
 
       def config
-        @_config ||= YAML
-          .load_file(config_file)
-          .values
-          .first
-          .merge(
-            "ynab_access_token" => ENV.fetch("YNAB_ACCESS_TOKEN"),
-            "moneyforward_username" => ENV.fetch("MONEYFORWARD_USERNAME"),
-            "moneyforward_password" => ENV.fetch("MONEYFORWARD_PASSWORD"),
-          )
+        @_config ||= Config.from_yaml(config_file, logger)
       end
 
       def logger

--- a/lib/mfynab/cli.rb
+++ b/lib/mfynab/cli.rb
@@ -46,7 +46,7 @@ module MFYNAB
 
       def ynab_transaction_importer
         @_ynab_transaction_importer ||= YnabTransactionImporter.new(
-          secrets["ynab_access_token"],
+          config.credentials["ynab_access_token"],
           config.ynab_budget,
           config.accounts,
           logger: logger,
@@ -59,18 +59,10 @@ module MFYNAB
 
       def session
         @_session ||= MoneyForward::Session.new(
-          username: secrets["moneyforward_username"],
-          password: secrets["moneyforward_password"],
+          username: config.credentials["moneyforward_username"],
+          password: config.credentials["moneyforward_password"],
           logger: logger,
         )
-      end
-
-      def secrets
-        {
-          "ynab_access_token" => ENV.fetch("YNAB_ACCESS_TOKEN"),
-          "moneyforward_username" => ENV.fetch("MONEYFORWARD_USERNAME"),
-          "moneyforward_password" => ENV.fetch("MONEYFORWARD_PASSWORD"),
-        }
       end
 
       def config_file

--- a/lib/mfynab/config.rb
+++ b/lib/mfynab/config.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "mfynab/credentials_normalizer"
+
 module MFYNAB
   class Config
     DEFAULT_MONTHS_TO_SYNC = 3
@@ -33,6 +35,10 @@ module MFYNAB
 
     def accounts
       hash_config.fetch("accounts", [])
+    end
+
+    def credentials
+      @_credentials ||= CredentialsNormalizer.new(hash_config, logger).normalize
     end
 
     private

--- a/lib/mfynab/config.rb
+++ b/lib/mfynab/config.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module MFYNAB
+  class Config
+    DEFAULT_MONTHS_TO_SYNC = 3
+
+    def initialize(hash_config, logger)
+      @hash_config = hash_config
+      @logger = logger
+    end
+
+    def self.from_yaml(file, logger)
+      yaml_data = YAML.load_file(file)
+      # Backwards compatibility: support old config files that still have a top-level key.
+      # TODO: at some point (major version bump), we should probably remove this.
+      unless yaml_data.key?("accounts")
+        logger.warn("Top-level key in configuration file is deprecated. Please remove it.")
+        yaml_data = yaml_data.values.first
+      end
+
+      raise "Invalid configuration file" unless yaml_data.key?("accounts")
+
+      new(yaml_data, logger)
+    end
+
+    def ynab_budget
+      hash_config.fetch("ynab_budget")
+    end
+
+    def months_to_sync
+      hash_config.fetch("months_to_sync", DEFAULT_MONTHS_TO_SYNC)
+    end
+
+    def accounts
+      hash_config.fetch("accounts", [])
+    end
+
+    private
+
+      attr_reader :hash_config, :logger
+  end
+end

--- a/lib/mfynab/credentials_normalizer.rb
+++ b/lib/mfynab/credentials_normalizer.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module MFYNAB
+  class CredentialsNormalizer
+    def initialize(hash_config, logger)
+      @hash_config = hash_config
+      @logger = logger
+    end
+
+    def normalize
+      config = hash_config["credentials"]
+      if config.nil?
+        logger.warn("No credentials found in configuration file. Please update your configuration file.")
+        # This provides backwards compatibility with old configuration files
+        # that did not include the new credentials.
+        # TODO: at some point (major version bump), we should probably remove this.
+        return {
+          "ynab_access_token" => ENV.fetch("YNAB_ACCESS_TOKEN"),
+          "moneyforward_username" => ENV.fetch("MONEYFORWARD_USERNAME"),
+          "moneyforward_password" => ENV.fetch("MONEYFORWARD_PASSWORD"),
+        }
+      end
+
+      config.transform_values { normalize_credential(_1) }
+    end
+
+    private
+
+      attr_reader :hash_config, :logger
+
+      def normalize_credential(value)
+        case value
+        when String
+          value
+        when Hash
+          if !value.key?("type") || value["type"] == "literal"
+            value.fetch("value")
+          elsif value["type"] == "env"
+            ENV.fetch(value.fetch("value"))
+          else
+            raise "Unknown credential type: #{value['type']}"
+          end
+        else
+          raise "Unknown credential type: #{value.class}"
+        end
+      end
+  end
+end

--- a/lib/mfynab/money_forward.rb
+++ b/lib/mfynab/money_forward.rb
@@ -32,6 +32,19 @@ module MFYNAB
       update_accounts(account_names, update_invalid: false)
     end
 
+    def fetch_data(months)
+      Dir.mktmpdir("mfynab") do |save_path|
+        download_csv(
+          path: save_path,
+          months: months,
+        )
+
+        MoneyForwardData.new(logger: logger).tap do |data|
+          data.read_all_csv(save_path)
+        end
+      end
+    end
+
     def download_csv(path:, months:)
       month = Date.today
       month -= month.day - 1 # First day of month

--- a/test/mfynab/config_test.rb
+++ b/test/mfynab/config_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "mfynab/config"
+require "support/test_loggers"
+
+module MFYNAB
+  class ConfigTest < Minitest::Test
+    include TestLoggers
+
+    def test_from_yaml_with_top_level_key
+      Tempfile.create do |file|
+        file.write(<<~YAML)
+          top_level_key:
+            ynab_budget: "budget_id"
+            accounts:
+              - money_forward_name: "mf account"
+                ynab_name: "ynab account"
+        YAML
+        file.close
+
+        config = Config.from_yaml(file.path, memory_logger)
+
+        assert_equal "budget_id", config.ynab_budget
+        assert_includes memory_logger.messages, "Top-level key in configuration file is deprecated. Please remove it."
+      end
+    end
+
+    def test_from_yaml_without_top_level_key
+      Tempfile.create do |file|
+        file.write(<<~YAML)
+          ynab_budget: "budget_id"
+          accounts:
+            - money_forward_name: "mf account"
+              ynab_name: "ynab account"
+        YAML
+        file.close
+
+        config = Config.from_yaml(file.path, null_logger)
+
+        assert_equal "budget_id", config.ynab_budget
+      end
+    end
+  end
+end

--- a/test/mfynab/credentials_normalizer_test.rb
+++ b/test/mfynab/credentials_normalizer_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "mfynab/credentials_normalizer"
+require "support/test_loggers"
+
+module MFYNAB
+  class CredentialsNormalizerTest < Minitest::Test
+    include TestLoggers
+
+    def test_backwards_compatibility_with_old_configuration_files
+      mock_env_credentials do
+        normalized = CredentialsNormalizer.new({}, memory_logger).normalize
+
+        assert_equal(expected_credentials, normalized)
+        assert_includes(
+          memory_logger.messages,
+          "No credentials found in configuration file. Please update your configuration file.",
+        )
+      end
+    end
+
+    def test_literal_credentials
+      hash_config = {
+        "credentials" => {
+          "ynab_access_token" => {
+            "type" => "literal",
+            "value" => "expected_ynab_access_token",
+          },
+          "moneyforward_username" => "expected_moneyforward_username",
+          "moneyforward_password" => "expected_moneyforward_password",
+        },
+      }
+      normalized = CredentialsNormalizer.new(hash_config, null_logger).normalize
+
+      assert_equal(expected_credentials, normalized)
+    end
+
+    def test_env_var_credentials
+      mock_env_credentials do
+        hash_config = {
+          "credentials" => {
+            "ynab_access_token" => {
+              "type" => "env",
+              "value" => "YNAB_ACCESS_TOKEN",
+            },
+            "moneyforward_username" => {
+              "type" => "env",
+              "value" => "MONEYFORWARD_USERNAME",
+            },
+            "moneyforward_password" => {
+              "type" => "env",
+              "value" => "MONEYFORWARD_PASSWORD",
+            },
+          },
+        }
+        normalized = CredentialsNormalizer.new(hash_config, null_logger).normalize
+
+        assert_equal(expected_credentials, normalized)
+      end
+    end
+
+    private
+
+      def expected_credentials
+        {
+          "ynab_access_token" => "expected_ynab_access_token",
+          "moneyforward_username" => "expected_moneyforward_username",
+          "moneyforward_password" => "expected_moneyforward_password",
+        }
+      end
+
+      def mock_env_credentials
+        old_env = ENV.to_h
+
+        ENV.update(
+          "YNAB_ACCESS_TOKEN" => "expected_ynab_access_token",
+          "MONEYFORWARD_USERNAME" => "expected_moneyforward_username",
+          "MONEYFORWARD_PASSWORD" => "expected_moneyforward_password",
+        )
+
+        yield
+      ensure
+        ENV.replace(old_env)
+      end
+  end
+end

--- a/test/support/test_loggers.rb
+++ b/test/support/test_loggers.rb
@@ -2,8 +2,23 @@
 
 module MFYNAB
   module TestLoggers
+    class MemoryLogger < Logger
+      def initialize
+        @log = StringIO.new
+        super(@log)
+      end
+
+      def messages
+        @log.string
+      end
+    end
+
     def null_logger
       @_null_logger ||= Logger.new(File::NULL)
+    end
+
+    def memory_logger
+      @_memory_logger ||= MemoryLogger.new
     end
   end
 end


### PR DESCRIPTION
- **Extract the `Config` concept**
- **Allow credentials to be stored in the YAML config file**

This will make it simpler to customize environment variable names.

See how [config/example.yml](https://github.com/davidstosik/mfynab/pull/68/files#diff-2e644c3e0f6d94c4823b6194a4badcd287f40704cd5d06f3d09f7a60c6a294cc) changed.